### PR TITLE
fix glitch at first launch, when menu is not open in viewWillAppear

### DIFF
--- a/DLWidgetMenu/Classes/DLWMMenu.m
+++ b/DLWidgetMenu/Classes/DLWMMenu.m
@@ -88,6 +88,7 @@ NSString * const DLWMMenuLayoutChangedNotification = @"DLWMMenuLayoutChangedNoti
 		self.layout = layout;
 		
 		[self reloadData];
+        [self adjustGeometryForState:DLWMMenuStateClosed];
 	}
 	return self;
 }


### PR DESCRIPTION
Hi,

When `[self.menu openAnimated:YES];` is **not** called in `viewDidAppear:`, there is a little glitch at the first launching of the app. The menu main view moves a little bit. 

Calling `adjustGeometryForState` in initialisation fix this problem.

Thanks for this component :) !
